### PR TITLE
Rescue from ArgumentError on invalid version

### DIFF
--- a/list-puppet-modules-with-outdated-dependency.rb
+++ b/list-puppet-modules-with-outdated-dependency.rb
@@ -94,6 +94,8 @@ while query
 
     summary[:ok] += 1
     info "#{name} (#{version_requirement}) is fine"
+  rescue ArgumentError
+    error("#{name} (#{version_requirement}): ignored (ArgumentError)")
   end
 
   query = json['pagination']['next']


### PR DESCRIPTION
When a version string cannot be parsed, an ArgumentError exception is
raised.

When this happen, catch the error, log the issue, and continue
processing modules.
